### PR TITLE
Fix crashing due to providing a server side villager to a render function

### DIFF
--- a/common/src/main/java/com/mrbysco/justenoughprofessions/VillagerCache.java
+++ b/common/src/main/java/com/mrbysco/justenoughprofessions/VillagerCache.java
@@ -2,11 +2,11 @@ package com.mrbysco.justenoughprofessions;
 
 import com.mrbysco.justenoughprofessions.platform.Services;
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.npc.Villager;
 import net.minecraft.world.entity.npc.VillagerProfession;
-import net.minecraft.world.level.Level;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Objects;
@@ -20,8 +20,7 @@ public class VillagerCache {
 		if (cachedVillager == null) {
 			CompoundTag nbt = new CompoundTag();
 			nbt.putString("id", Objects.requireNonNull(Services.PLATFORM.getEntityKey(EntityType.VILLAGER)).toString());
-			Minecraft mc = Minecraft.getInstance();
-			Level level = mc.hasSingleplayerServer() && mc.getSingleplayerServer() != null ? mc.getSingleplayerServer().getAllLevels().iterator().next() : mc.level;
+			ClientLevel level = Minecraft.getInstance().level;
 			if (level != null) {
 				Villager villager = (Villager) EntityType.loadEntityRecursive(nbt, level, Function.identity());
 				if (villager != null) {


### PR DESCRIPTION
Fixes #15 
Code to reproduce:
```java
	@SubscribeEvent
	public static void thingytestthingy(LevelTickEvent.Post event) {
		if (event.getLevel() instanceof ServerLevel sl) {
			for (int i = 0; i < 100; i++)
				sl.random.nextDouble();
			sl.getServer().sendSystemMessage(Component.literal("Generated lots of random numbers!"));
		}
	}

	@SubscribeEvent
	public static void otherthingtestthing(RenderLivingEvent.Post event) {
		for (int i = 0; i < 100; i++)
			event.getEntity().level().random.nextDouble();
	}
```